### PR TITLE
Fix https://github.com/phobon/fragments-boilerplate-vanilla/issues/4

### DIFF
--- a/src/sketches/flare-1.js
+++ b/src/sketches/flare-1.js
@@ -12,7 +12,8 @@
  */
 
 import { abs, Fn, oneMinus, screenSize, uv, vec3, floor, sin, PI, mul, Loop, vec2 } from 'three/tsl'
-import { grain } from '@/tsl/utils/texture'
+import { grainTextureEffect } from '@/tsl/post_processing/grain_texture_effect'
+// import { grain } from '@/tsl/utils/texture'
 import { cosinePalette } from '@/tsl/utils/color/cosine_palette'
 import { screenAspectUV } from '@/tsl/utils/function/screen_aspect_uv'
 /**
@@ -54,7 +55,8 @@ const flare1 = Fn(() => {
     finalColor.assign(col.mul(r))
   })
   // Add grain for texture
-  const g = grain(uv0).mul(0.1)
+  const g = grainTextureEffect(uv0).mul(0.1)
+  // const g = grain(uv0).mul(0.1)
   finalColor.addAssign(g)
 
   return finalColor

--- a/src/sketches/noise/dawn-1.js
+++ b/src/sketches/noise/dawn-1.js
@@ -12,6 +12,7 @@
  */
 
 import { Fn, screenSize, vec3, fract, pow, time } from 'three/tsl'
+// import { grainTextureEffect } from '@/tsl/post_processing/grain_texture_effect'
 import { grain } from '@/tsl/utils/texture'
 import { cosinePalette } from '@/tsl/utils/color/cosine_palette'
 import { screenAspectUV } from '@/tsl/utils/function/screen_aspect_uv'
@@ -43,7 +44,8 @@ const dawn1 = Fn(() => {
   finalColor.assign(col.add(pow(repeatedPattern, 2.0)))
 
   // Add grain for texture
-  const _grain = grain(_uv).mul(0.2)
+  // const _grain = grainTextureEffect(_uv).mul(0.2)
+  const _grain = grain(_uv.mul(0.5)).mul(0.2)
   finalColor.addAssign(_grain)
 
   return finalColor

--- a/src/tsl/utils/texture.js
+++ b/src/tsl/utils/texture.js
@@ -1,0 +1,10 @@
+import { vec2, Fn, fract, sin, dot } from 'three/tsl'
+
+/**
+ * Returns a grain texture value for a given UV coordinate.
+ * @param {vec2} _uv - The UV coordinates.
+ * @returns {float} The grain value.
+ */
+export const grain = Fn(([_uv]) => {
+  return fract(sin(dot(_uv, vec2(12.9898, 78.233))).mul(43758.5453123))
+})


### PR DESCRIPTION
Fixes https://github.com/phobon/fragments-boilerplate-vanilla/issues/4

The issue is caused by the import point to a file `import { grain } from '@/tsl/utils/texture' that doesn't exist in this project, but it does exist in the React project. 

It looks the `grain` function is implemented in `@/tsl/post_processing/grain_texture_effect' in both projects as well.

I added the file again under the `@/tsl/utils/texture` path to keep consistent with React for now.

Presumably, one of these paths should be removed in both projects, but I left both in for now and kept the duplicate import (commented out) in the demo files -- I think this should be removed before merging.